### PR TITLE
fix(networking): bugs squashed, tests passing, k256 now working

### DIFF
--- a/crates/networking/src/handlers/connections.rs
+++ b/crates/networking/src/handlers/connections.rs
@@ -23,7 +23,6 @@ impl NetworkService<'_> {
         {
             let my_peer_id = *self.swarm.local_peer_id();
             let msg = my_peer_id.to_bytes();
-            //let hash = blake3_256(&msg);
             match <Curve as KeyType>::sign_with_secret(&mut self.secret_key.clone(), &msg) {
                 Ok(signature) => {
                     let handshake = MyBehaviourRequest::Handshake {

--- a/crates/networking/src/handlers/connections.rs
+++ b/crates/networking/src/handlers/connections.rs
@@ -2,7 +2,7 @@
 
 use crate::gossip::{MyBehaviourRequest, NetworkService};
 use crate::key_types::Curve;
-use gadget_crypto::{hashing::blake3_256, KeyType};
+use gadget_crypto::KeyType;
 use itertools::Itertools;
 use libp2p::PeerId;
 
@@ -23,11 +23,8 @@ impl NetworkService<'_> {
         {
             let my_peer_id = *self.swarm.local_peer_id();
             let msg = my_peer_id.to_bytes();
-            let hash = blake3_256(&msg);
-            match <Curve as KeyType>::sign_with_secret_pre_hashed(
-                &mut self.secret_key.clone(),
-                &hash,
-            ) {
+            //let hash = blake3_256(&msg);
+            match <Curve as KeyType>::sign_with_secret(&mut self.secret_key.clone(), &msg) {
                 Ok(signature) => {
                     let handshake = MyBehaviourRequest::Handshake {
                         public_key: self.secret_key.public(),

--- a/crates/networking/src/handlers/gossip.rs
+++ b/crates/networking/src/handlers/gossip.rs
@@ -98,7 +98,7 @@ impl NetworkService<'_> {
                     .find(|r| r.0.to_string() == topic)
                 {
                     if let Err(e) = tx.send(raw_payload) {
-                        gadget_logging::error!("Failed to send message to worker: {e}");
+                        gadget_logging::warn!("Failed to send message to worker: {e}");
                     }
                 } else {
                     gadget_logging::error!("No registered worker for topic: {topic}!");

--- a/crates/networking/src/handlers/p2p.rs
+++ b/crates/networking/src/handlers/p2p.rs
@@ -90,7 +90,6 @@ impl NetworkService<'_> {
                 gadget_logging::trace!("Received handshake from peer: {peer}");
                 // Verify the signature
                 let msg = peer.to_bytes();
-                //let hash = blake3_256(&msg);
                 let valid = <Curve as KeyType>::verify(&public_key, &msg, &signature);
                 if !valid {
                     gadget_logging::warn!("Invalid initial handshake signature from peer: {peer}");
@@ -109,7 +108,6 @@ impl NetworkService<'_> {
                 // Send response with our public key
                 let my_peer_id = self.swarm.local_peer_id();
                 let msg = my_peer_id.to_bytes();
-                //let hash = blake3_256(&msg);
                 match <Curve as KeyType>::sign_with_secret(&mut self.secret_key.clone(), &msg) {
                     Ok(signature) => self.swarm.behaviour_mut().p2p.send_response(
                         channel,
@@ -168,7 +166,6 @@ impl NetworkService<'_> {
             } => {
                 gadget_logging::trace!("Received handshake-ack message from peer: {peer}");
                 let msg = peer.to_bytes();
-                //let hash = blake3_256(&msg);
                 let valid = <Curve as KeyType>::verify(&public_key, &msg, &signature);
                 if !valid {
                     gadget_logging::warn!(

--- a/crates/networking/src/handlers/p2p.rs
+++ b/crates/networking/src/handlers/p2p.rs
@@ -2,7 +2,6 @@
 
 use crate::gossip::{MyBehaviourRequest, MyBehaviourResponse, NetworkService};
 use crate::key_types::Curve;
-use gadget_crypto::hashing::blake3_256;
 use gadget_crypto::KeyType;
 use gadget_std::string::ToString;
 use libp2p::gossipsub::IdentTopic;
@@ -91,10 +90,10 @@ impl NetworkService<'_> {
                 gadget_logging::trace!("Received handshake from peer: {peer}");
                 // Verify the signature
                 let msg = peer.to_bytes();
-                let hash = blake3_256(&msg);
-                let valid = <Curve as KeyType>::verify(&public_key, &hash, &signature);
+                //let hash = blake3_256(&msg);
+                let valid = <Curve as KeyType>::verify(&public_key, &msg, &signature);
                 if !valid {
-                    gadget_logging::warn!("Invalid signature from peer: {peer}");
+                    gadget_logging::warn!("Invalid initial handshake signature from peer: {peer}");
                     let _ = self.swarm.disconnect_peer_id(peer);
                     return;
                 }
@@ -110,11 +109,8 @@ impl NetworkService<'_> {
                 // Send response with our public key
                 let my_peer_id = self.swarm.local_peer_id();
                 let msg = my_peer_id.to_bytes();
-                let hash = blake3_256(&msg);
-                match <Curve as KeyType>::sign_with_secret_pre_hashed(
-                    &mut self.secret_key.clone(),
-                    &hash,
-                ) {
+                //let hash = blake3_256(&msg);
+                match <Curve as KeyType>::sign_with_secret(&mut self.secret_key.clone(), &msg) {
                     Ok(signature) => self.swarm.behaviour_mut().p2p.send_response(
                         channel,
                         MyBehaviourResponse::Handshaked {
@@ -141,7 +137,7 @@ impl NetworkService<'_> {
                     .find(|r| r.0.to_string() == topic.to_string())
                 {
                     if let Err(e) = tx.send(raw_payload) {
-                        gadget_logging::error!("Failed to send message to worker: {e}");
+                        gadget_logging::warn!("Failed to send message to worker: {e}");
                     }
                 } else {
                     gadget_logging::error!("No registered worker for topic: {topic}!");
@@ -172,10 +168,12 @@ impl NetworkService<'_> {
             } => {
                 gadget_logging::trace!("Received handshake-ack message from peer: {peer}");
                 let msg = peer.to_bytes();
-                let hash = blake3_256(&msg);
-                let valid = <Curve as KeyType>::verify(&public_key, &hash, &signature);
+                //let hash = blake3_256(&msg);
+                let valid = <Curve as KeyType>::verify(&public_key, &msg, &signature);
                 if !valid {
-                    gadget_logging::warn!("Invalid signature from peer: {peer}");
+                    gadget_logging::warn!(
+                        "Invalid handshake-acknowledgement signature from peer: {peer}"
+                    );
                     // TODO: report this peer.
                     self.public_key_to_libp2p_id
                         .write()

--- a/crates/networking/src/round_based_compat.rs
+++ b/crates/networking/src/round_based_compat.rs
@@ -1,6 +1,6 @@
 use crate::key_types::PublicKey;
 use crate::networking::{
-    IdentifierInfo, NetworkMultiplexer, ProtocolMessage, StreamKey, SubNetwork,
+    IdentifierInfo, Network, NetworkMultiplexer, ProtocolMessage, StreamKey, SubNetwork,
 };
 use core::pin::Pin;
 use core::sync::atomic::AtomicU64;
@@ -186,6 +186,8 @@ where
             return Err(crate::Error::Other("Recipient not found".to_string()));
         }
 
+        // Manually construct a `ProtocolMessage` since rounds-based
+        // does not work well with bincode
         let protocol_message = ProtocolMessage {
             identifier_info,
             sender: ParticipantInfo {

--- a/crates/networking/src/setup.rs
+++ b/crates/networking/src/setup.rs
@@ -159,6 +159,7 @@ pub fn multiplexed_libp2p_network(config: NetworkConfig) -> NetworkResult {
 
     let networks = topics;
 
+    let my_pk = secret_key.public();
     let my_id = identity.public().to_peer_id();
 
     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(identity)
@@ -270,7 +271,7 @@ pub fn multiplexed_libp2p_network(config: NetworkConfig) -> NetworkResult {
                 public_key_to_libp2p_id: public_key_to_libp2p_id.clone(),
                 // Each key is 32 bytes, therefore 512 messages hashes can be stored in the set
                 recent_messages: LruCache::new(16 * 1024).into(),
-                my_id,
+                my_id: my_pk,
             },
         );
     }


### PR DESCRIPTION
Why `k256` didn't work in `gadget-networking`: we used a custom hashing algorithm for signing the hash, then upon verification, not every library expected data to be prehashed. The solution was to not prehash, and delegate to the individual libraries for hashing determination.

Duplicate messages: We had no checks in the networking layer for messages being delivered to the wrong person, which meant that if messages were improperly created, they would be received by an unsuspecting user.